### PR TITLE
Development

### DIFF
--- a/DataPackageManager/src/edu/lternet/pasta/datapackagemanager/solr/index/SolrIndex.java
+++ b/DataPackageManager/src/edu/lternet/pasta/datapackagemanager/solr/index/SolrIndex.java
@@ -59,7 +59,7 @@ public class SolrIndex {
 	 */
 	public void commit() throws IOException, SolrServerException {
 		solrClient.commit();
-		solrClient.close();
+		// solrClient.close();
 	}
 	
 

--- a/common/build.xml
+++ b/common/build.xml
@@ -26,10 +26,8 @@
     <copy todir="${lib.dir}" preservelastmodified="true" verbose="true"
           filtering="no">
       <fileset dir="${shared.lib.dir}/jersey">
-        <include name="jersey-core-1.4.jar"/>
-        <include name="jersey-server-1.4.jar"/>
-        <include name="jersey-client-1.4.jar"/>
-      </fileset>
+		<include name="**/*.jar"/>
+	  </fileset>
       <fileset dir="${shared.lib.dir}/junit">
         <include name="junit-4.8.2.jar"/>
       </fileset>


### PR DESCRIPTION
Apparently, closing the solrClient at this point results in a connection pool shutdown after 100 commits. Removing this solrClient.close() seems to mitigate this issue.