### PR TITLE
Revert explict closing solr client during indexing to resolve connect…

### DIFF
--- a/DataPackageManager/src/edu/lternet/pasta/datapackagemanager/solr/index/SolrIndex.java
+++ b/DataPackageManager/src/edu/lternet/pasta/datapackagemanager/solr/index/SolrIndex.java
@@ -59,7 +59,7 @@ public class SolrIndex {
 	 */
 	public void commit() throws IOException, SolrServerException {
 		solrClient.commit();
-		solrClient.close();
+		// solrClient.close();
 	}
 	
 


### PR DESCRIPTION
Apparently, closing the solrClient at this point results in a connection pool shutdown after 100 commits. Removing this solrClient.close() seems to mitigate this issue.